### PR TITLE
feat: Add GoogleAnalytics tracking

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -46,3 +46,15 @@ ignoreErrors = ["error-disable-taxonomy"]
 
   [Params.social]
     twitter = "d2iq_eng"
+
+[privacy]
+  [privacy.googleAnalytics]
+    anonymizeIP = true
+    respectDoNotTrack = true
+    useSessionStorage = true
+  [privacy.twitter]
+    enableDNT = true
+  [privacy.vimeo]
+    enableDNT = true
+  [privacy.youtube]
+    privacyEnhanced = true

--- a/themes/casperv5/layouts/partials/head.html
+++ b/themes/casperv5/layouts/partials/head.html
@@ -43,4 +43,9 @@
     <link rel="stylesheet" href="{{ .RelPermalink }}" integrity="{{ .Data.Integrity }}" />
   {{ end }}
 {{ end }}
+
+{{- if not .Site.IsServer -}}
+  {{ template "_internal/google_analytics.html" . }}
+{{- end -}}
+
 </head>


### PR DESCRIPTION
Configure for GDPR compliance.

Tracking code is provided by setting `HUGO_GOOGLEANALYTICS` environment variable
set in Netlify configuration for production deploys only. This means that tracking
will only be included in production builds, rather than deploy previews or local
server builds.
