### PR TITLE
build: Add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mesosphere/d2iq-tag


### PR DESCRIPTION
Add CODEOWNERS file to automatically request approvals from @mesosphere/d2iq-tag team.