### PR TITLE
fix: Use textContent instead of innerText in clipboard func

### DIFF
--- a/themes/casperv5/assets/js/clipboard.js
+++ b/themes/casperv5/assets/js/clipboard.js
@@ -12,7 +12,7 @@ const addCopyButtons = (clipboard) => {
     button.type = "button";
     button.innerHTML = svgCopy;
     button.addEventListener("click", () => {
-      clipboard.writeText(codeBlock.innerText).then(
+      clipboard.writeText(codeBlock.textContent).then(
         () => {
           button.blur();
           button.innerHTML = svgCheck;


### PR DESCRIPTION
Fixes #92.
